### PR TITLE
feat: support custom groups

### DIFF
--- a/dsp_permissions_scripts/main.py
+++ b/dsp_permissions_scripts/main.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 from dotenv import load_dotenv
 
-from dsp_permissions_scripts.models.groups import BuiltinGroup
+from dsp_permissions_scripts.models.groups import Group
 from dsp_permissions_scripts.models.host import Hosts
 from dsp_permissions_scripts.models.permission import PermissionScopeElement
 from dsp_permissions_scripts.models.scope import StandardScope
@@ -29,7 +29,7 @@ def main() -> None:
     host = Hosts.get_host("test")
     shortcode = "F18E"
     new_scope = StandardScope().PUBLIC
-    groups = [BuiltinGroup.PROJECT_ADMIN, BuiltinGroup.PROJECT_MEMBER]
+    groups = [Group.PROJECT_ADMIN, Group.PROJECT_MEMBER]
     token = login(host)
     print_doaps_of_project(
         host=host,
@@ -98,7 +98,7 @@ def set_oaps_of_resources(
 
 def set_doaps_of_groups(
     scope: list[PermissionScopeElement],
-    groups: Sequence[str | BuiltinGroup],
+    groups: Sequence[str | Group],
     host: str,
     shortcode: str,
     token: str,

--- a/dsp_permissions_scripts/models/groups.py
+++ b/dsp_permissions_scripts/models/groups.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
 
-class BuiltinGroup(Enum):
+class Group(Enum):
     """
-    Enumeration of the built in DSP user groups.
+    Enumeration of DSP user groups (built-in or custom).
     """
 
     UNKNOWN_USER = "http://www.knora.org/ontology/knora-admin#UnknownUser"

--- a/dsp_permissions_scripts/models/permission.py
+++ b/dsp_permissions_scripts/models/permission.py
@@ -2,17 +2,17 @@ from typing import Self
 
 from pydantic import BaseModel, field_validator, model_validator
 
-from dsp_permissions_scripts.models.groups import BuiltinGroup
+from dsp_permissions_scripts.models.groups import Group
 
 
 class PermissionScopeElement(BaseModel):
-    info: str | BuiltinGroup
+    info: str | Group
     name: str
 
     @field_validator("info")
     @classmethod
-    def info_must_represent_group_iri(cls, v: str | BuiltinGroup) -> str | BuiltinGroup:
-        assert v in [x.value for x in BuiltinGroup]
+    def info_must_represent_group_iri(cls, v: str | Group) -> str | Group:
+        assert v in [x.value for x in Group]
         return v
 
     @field_validator("name")

--- a/dsp_permissions_scripts/models/scope.py
+++ b/dsp_permissions_scripts/models/scope.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from dsp_permissions_scripts.models.groups import BuiltinGroup
+from dsp_permissions_scripts.models.groups import Group
 from dsp_permissions_scripts.models.permission import PermissionScopeElement
 
 
@@ -17,18 +17,18 @@ class StandardScope:
 
     def __init__(self):
         self.PUBLIC = self._make_scope(
-            view=[BuiltinGroup.UNKNOWN_USER, BuiltinGroup.KNOWN_USER],
-            change_rights=[BuiltinGroup.PROJECT_ADMIN],
-            delete=[BuiltinGroup.CREATOR, BuiltinGroup.PROJECT_MEMBER],
+            view=[Group.UNKNOWN_USER, Group.KNOWN_USER],
+            change_rights=[Group.PROJECT_ADMIN],
+            delete=[Group.CREATOR, Group.PROJECT_MEMBER],
         )
 
     def _make_scope(
         self,
-        restricted_view: Sequence[str | BuiltinGroup] = (),
-        view: Sequence[str | BuiltinGroup] = (),
-        modify: Sequence[str | BuiltinGroup] = (),
-        delete: Sequence[str | BuiltinGroup] = (),
-        change_rights: Sequence[str | BuiltinGroup] = (),
+        restricted_view: Sequence[str | Group] = (),
+        view: Sequence[str | Group] = (),
+        modify: Sequence[str | Group] = (),
+        delete: Sequence[str | Group] = (),
+        change_rights: Sequence[str | Group] = (),
     ) -> list[PermissionScopeElement]:
         """
         Create scopes by providing group IRIs for different permission levels.

--- a/dsp_permissions_scripts/utils/permissions.py
+++ b/dsp_permissions_scripts/utils/permissions.py
@@ -4,7 +4,7 @@ from urllib.parse import quote_plus
 
 import requests
 
-from dsp_permissions_scripts.models.groups import BuiltinGroup
+from dsp_permissions_scripts.models.groups import Group
 from dsp_permissions_scripts.models.permission import Doap, DoapTarget, PermissionScopeElement
 from dsp_permissions_scripts.models.value import ValueUpdate
 from dsp_permissions_scripts.utils.project import get_project_iri_by_shortcode
@@ -86,7 +86,7 @@ def get_doaps_for_project(
 
 
 def get_doaps_of_groups(
-    groups: Sequence[str | BuiltinGroup],
+    groups: Sequence[str | Group],
     host: str,
     shortcode: str,
     token: str,
@@ -114,7 +114,7 @@ def get_doaps_of_groups(
     )
     groups_str = []
     for g in groups:
-        groups_str.append(g.value if isinstance(g, BuiltinGroup) else g)
+        groups_str.append(g.value if isinstance(g, Group) else g)
     applicable_doaps = [d for d in all_doaps if d.target.group in groups_str]
     assert len(applicable_doaps) == len(groups)
     return applicable_doaps


### PR DESCRIPTION
Currently, only "BuiltinGroups" are supported, otherwise I get an error. So I renamed it to "Group", so that I can add the custom group "group-scenario-tanner"