### PR TITLE
fix: remove SystemUser from built-in groups

### DIFF
--- a/dsp_permissions_scripts/models/groups.py
+++ b/dsp_permissions_scripts/models/groups.py
@@ -11,5 +11,4 @@ class BuiltinGroup(Enum):
     CREATOR = "http://www.knora.org/ontology/knora-admin#Creator"
     PROJECT_MEMBER = "http://www.knora.org/ontology/knora-admin#ProjectMember"
     PROJECT_ADMIN = "http://www.knora.org/ontology/knora-admin#ProjectAdmin"
-    SYSTEM_USER = "http://www.knora.org/ontology/knora-admin#SystemUser"
     SYSTEM_ADMIN = "http://www.knora.org/ontology/knora-admin#SystemAdmin"

--- a/tests/test_scope_serialization.py
+++ b/tests/test_scope_serialization.py
@@ -13,14 +13,14 @@ from dsp_permissions_scripts.utils.scope_serialization import (
 
 class TestScopeSerialization(unittest.TestCase):
     perm_strings = [
-        "CR knora-admin:SystemUser|V knora-admin:CustomGroup",
+        "CR knora-admin:SystemAdmin|V knora-admin:CustomGroup",
         "D knora-admin:ProjectAdmin|RV knora-admin:ProjectMember",
         "M knora-admin:ProjectAdmin|V knora-admin:Creator,knora-admin:KnownUser|RV knora-admin:UnknownUser",
         "CR knora-admin:SystemAdmin,knora-admin:ProjectAdmin|D knora-admin:Creator|RV knora-admin:UnknownUser",
     ]
     admin_route_objects = [
         [
-            {"name": "CR", "additionalInformation": "knora-admin:SystemUser", "permissionCode": None},
+            {"name": "CR", "additionalInformation": "knora-admin:SystemAdmin", "permissionCode": None},
             {"name": "V", "additionalInformation": "knora-admin:CustomGroup", "permissionCode": None},
         ],
         [
@@ -42,7 +42,7 @@ class TestScopeSerialization(unittest.TestCase):
     ]
     scopes = [
         PermissionScope(
-            CR=[BuiltinGroup.SYSTEM_USER],
+            CR=[BuiltinGroup.SYSTEM_ADMIN],
             V=["http://www.knora.org/ontology/knora-admin#CustomGroup"],
         ),
         PermissionScope(


### PR DESCRIPTION
`knora-admin:SystemUser` is a built-in user, not a built-in group, see https://docs.dasch.swiss/2023.10.01/DSP-API/05-internals/design/domain/system-instances/