### PR TITLE
improve: apply only modified OAPs on server

### DIFF
--- a/dsp_permissions_scripts/oap/oap_set.py
+++ b/dsp_permissions_scripts/oap/oap_set.py
@@ -1,5 +1,4 @@
 import itertools
-import re
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 from datetime import datetime
@@ -8,7 +7,7 @@ from dsp_permissions_scripts.models.errors import ApiError
 from dsp_permissions_scripts.models.errors import PermissionsAlreadyUpToDate
 from dsp_permissions_scripts.models.scope import PermissionScope
 from dsp_permissions_scripts.oap.oap_get import get_resource
-from dsp_permissions_scripts.oap.oap_model import Oap
+from dsp_permissions_scripts.oap.oap_model import ResourceOap
 from dsp_permissions_scripts.oap.oap_model import ValueOap
 from dsp_permissions_scripts.utils.dsp_client import DspClient
 from dsp_permissions_scripts.utils.get_logger import get_logger
@@ -72,45 +71,42 @@ def _update_permissions_for_resource(  # noqa: PLR0913
         raise err from None
 
 
-def _update_batch(batch: tuple[Oap, ...], dsp_client: DspClient) -> list[str]:
+def _update_batch(batch: tuple[ResourceOap | ValueOap, ...], dsp_client: DspClient) -> list[str]:
     failed_iris = []
     for oap in batch:
-        resource_iri = (
-            oap.resource_oap.resource_iri
-            if oap.resource_oap
-            else re.sub(r"/values/.+$", "", oap.value_oaps[0].value_iri)
-        )
         try:
-            resource = get_resource(resource_iri, dsp_client)
+            resource = get_resource(oap.resource_iri, dsp_client)
         except Exception as exc:  # noqa: BLE001
-            logger.error(f"Cannot update resource {resource_iri}: {exc}")
-            failed_iris.append(resource_iri)
+            logger.error(f"Cannot update resource {oap.resource_iri}: {exc}")
+            failed_iris.append(oap.resource_iri)
             continue
-        if oap.resource_oap:
+        if isinstance(oap, ResourceOap):
             try:
                 _update_permissions_for_resource(
-                    resource_iri=resource_iri,
+                    resource_iri=oap.resource_iri,
                     lmd=resource.get("knora-api:lastModificationDate"),
                     resource_type=resource["@type"],
                     context=resource["@context"],
-                    scope=oap.resource_oap.scope,
+                    scope=oap.scope,
                     dsp_client=dsp_client,
                 )
             except ApiError as err:
                 logger.error(err)
-                failed_iris.append(resource_iri)
-        for v in oap.value_oaps:
+                failed_iris.append(oap.resource_iri)
+        elif isinstance(oap, ValueOap):
             try:
                 _update_permissions_for_value(
-                    resource_iri=resource_iri,
-                    value=v,
+                    resource_iri=oap.resource_iri,
+                    value=oap,
                     resource_type=resource["@type"],
                     context=resource["@context"],
                     dsp_client=dsp_client,
                 )
             except ApiError as err:
                 logger.error(err)
-                failed_iris.append(v.value_iri)
+                failed_iris.append(oap.value_iri)
+        else:
+            raise ValueError(f"The provided OAP is neither a resource OAP nor a value OAP: {oap}")
     return failed_iris
 
 
@@ -125,7 +121,7 @@ def _write_failed_iris_to_file(
         f.write("\n".join(failed_iris))
 
 
-def _launch_thread_pool(oaps: list[Oap], nthreads: int, dsp_client: DspClient) -> list[str]:
+def _launch_thread_pool(oaps: list[ResourceOap | ValueOap], nthreads: int, dsp_client: DspClient) -> list[str]:
     all_failed_iris: list[str] = []
     with ThreadPoolExecutor(max_workers=nthreads) as pool:
         jobs = [pool.submit(_update_batch, batch, dsp_client) for batch in itertools.batched(oaps, 100)]
@@ -136,7 +132,7 @@ def _launch_thread_pool(oaps: list[Oap], nthreads: int, dsp_client: DspClient) -
 
 
 def apply_updated_oaps_on_server(
-    oaps: list[Oap],
+    oaps: list[ResourceOap | ValueOap],
     host: str,
     shortcode: str,
     dsp_client: DspClient,
@@ -149,9 +145,7 @@ def apply_updated_oaps_on_server(
     if not oaps:
         logger.warning(f"There are no OAPs to update on {host}")
         return
-    value_oap_count = sum(len(oap.value_oaps) for oap in oaps)
-    res_oap_count = sum(1 for oap in oaps if oap.resource_oap)
-    logger.info(f"******* Updating {res_oap_count} resource OAPs and {value_oap_count} value OAPs on {host}... *******")
+    logger.info(f"******* Updating OAPs of {len(oaps)} resources and/or values on {host}... *******")
 
     failed_iris = _launch_thread_pool(oaps, nthreads, dsp_client)
     if failed_iris:

--- a/dsp_permissions_scripts/oap/oap_set.py
+++ b/dsp_permissions_scripts/oap/oap_set.py
@@ -145,7 +145,9 @@ def apply_updated_oaps_on_server(
     if not oaps:
         logger.warning(f"There are no OAPs to update on {host}")
         return
-    logger.info(f"******* Updating OAPs of {len(oaps)} resources and/or values on {host}... *******")
+    value_oap_count = sum(isinstance(oap, ValueOap) for oap in oaps)
+    res_oap_count = sum(isinstance(oap, ResourceOap) for oap in oaps)
+    logger.info(f"******* Updating {res_oap_count} resource OAPs and {value_oap_count} value OAPs on {host}... *******")
 
     failed_iris = _launch_thread_pool(oaps, nthreads, dsp_client)
     if failed_iris:

--- a/dsp_permissions_scripts/template.py
+++ b/dsp_permissions_scripts/template.py
@@ -16,6 +16,8 @@ from dsp_permissions_scripts.models.scope import PUBLIC
 from dsp_permissions_scripts.oap.oap_get import get_all_oaps_of_project
 from dsp_permissions_scripts.oap.oap_model import Oap
 from dsp_permissions_scripts.oap.oap_model import OapRetrieveConfig
+from dsp_permissions_scripts.oap.oap_model import ResourceOap
+from dsp_permissions_scripts.oap.oap_model import ValueOap
 from dsp_permissions_scripts.oap.oap_serialize import serialize_oaps
 from dsp_permissions_scripts.oap.oap_set import apply_updated_oaps_on_server
 from dsp_permissions_scripts.utils.authentication import login
@@ -47,21 +49,18 @@ def modify_doaps(doaps: list[Doap]) -> list[Doap]:
     return modified_doaps
 
 
-def modify_oaps(oaps: list[Oap]) -> list[Oap]:
+def modify_oaps(oaps: list[Oap]) -> list[ResourceOap | ValueOap]:
     """Adapt this sample to your needs."""
-    modified_oaps = []
+    modified_oaps: list[ResourceOap | ValueOap] = []
     for oap in copy.deepcopy(oaps):
-        modified = False
         if oap.resource_oap:
             if group.SYSTEM_ADMIN not in oap.resource_oap.scope.CR:
                 oap.resource_oap.scope = oap.resource_oap.scope.add("CR", group.SYSTEM_ADMIN)
-                modified = True
+                modified_oaps.append(oap.resource_oap)
         for value_oap in oap.value_oaps:
             if group.SYSTEM_ADMIN not in value_oap.scope.CR:
                 value_oap.scope = value_oap.scope.add("CR", group.SYSTEM_ADMIN)
-                modified = True
-        if modified:
-            modified_oaps.append(oap)
+                modified_oaps.append(value_oap)
     return modified_oaps
 
 

--- a/tests/test_oap_serialization.py
+++ b/tests/test_oap_serialization.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
-from pytest_unordered import unordered
 
 from dsp_permissions_scripts.models import group
 from dsp_permissions_scripts.models.scope import PermissionScope
@@ -31,7 +30,7 @@ class TestOapSerialization:
         oaps_original = [oap1, oap2, oap3]
         serialize_oaps(oaps_original, self.shortcode, "original")
         deserialized_oaps = deserialize_oaps(self.shortcode, "original")
-        assert unordered(oaps_original) == deserialized_oaps
+        assert oaps_original == deserialized_oaps
 
     def _get_oap_full(self) -> Oap:
         scope = PermissionScope.create(CR=[group.PROJECT_ADMIN], V=[group.PROJECT_MEMBER])

--- a/tests/test_oap_serialization.py
+++ b/tests/test_oap_serialization.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+from pytest_unordered import unordered
 
 from dsp_permissions_scripts.models import group
 from dsp_permissions_scripts.models.scope import PermissionScope
@@ -30,7 +31,7 @@ class TestOapSerialization:
         oaps_original = [oap1, oap2, oap3]
         serialize_oaps(oaps_original, self.shortcode, "original")
         deserialized_oaps = deserialize_oaps(self.shortcode, "original")
-        assert oaps_original == deserialized_oaps
+        assert unordered(oaps_original) == deserialized_oaps
 
     def _get_oap_full(self) -> Oap:
         scope = PermissionScope.create(CR=[group.PROJECT_ADMIN], V=[group.PROJECT_MEMBER])


### PR DESCRIPTION
Instead of sending an update request for a resource and all its values, send only update requests for the specific resource (or specific value) of which the permissions have been modified.