### PR TITLE
fix: maintain order of groups

### DIFF
--- a/dsp_permissions_scripts/models/scope.py
+++ b/dsp_permissions_scripts/models/scope.py
@@ -120,18 +120,18 @@ class PermissionScope(BaseModel):
 
 
 OPEN = PermissionScope.create(
-    CR={PROJECT_ADMIN},
-    D={PROJECT_MEMBER},
-    V={KNOWN_USER, UNKNOWN_USER},
+    CR=[PROJECT_ADMIN],
+    D=[PROJECT_MEMBER],
+    V=[KNOWN_USER, UNKNOWN_USER],
 )
 
 RESTRICTED_VIEW = PermissionScope.create(
-    CR={PROJECT_ADMIN},
-    D={PROJECT_MEMBER},
-    RV={KNOWN_USER, UNKNOWN_USER},
+    CR=[PROJECT_ADMIN],
+    D=[PROJECT_MEMBER],
+    RV=[KNOWN_USER, UNKNOWN_USER],
 )
 
 RESTRICTED = PermissionScope.create(
-    CR={PROJECT_ADMIN},
-    D={PROJECT_MEMBER},
+    CR=[PROJECT_ADMIN],
+    D=[PROJECT_MEMBER],
 )

--- a/tests/test_doap_set.py
+++ b/tests/test_doap_set.py
@@ -57,7 +57,7 @@ def test_create_new_doap_on_server(
     _ = create_new_doap_on_server(
         target=NewGroupDoapTarget(group=group.KNOWN_USER),
         shortcode="0000",
-        scope=PermissionScope.create(V={group.UNKNOWN_USER}),
+        scope=PermissionScope.create(V=[group.UNKNOWN_USER]),
         dsp_client=dsp_client,
     )
     dsp_client.post.assert_called_once_with("/admin/permissions/doap", data=create_new_doap_request)

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -15,23 +15,23 @@ class TestScopeCreation:
             M=frozenset({group.PROJECT_MEMBER, group.KNOWN_USER}),
             V=frozenset({group.UNKNOWN_USER}),
         )
-        assert scope.CR == frozenset({group.SYSTEM_ADMIN})
-        assert scope.D == frozenset({group.PROJECT_ADMIN})
-        assert scope.M == frozenset({group.PROJECT_MEMBER, group.KNOWN_USER})
-        assert scope.V == frozenset({group.UNKNOWN_USER})
+        assert scope.CR == frozenset([group.SYSTEM_ADMIN])
+        assert scope.D == frozenset([group.PROJECT_ADMIN])
+        assert scope.M == frozenset([group.PROJECT_MEMBER, group.KNOWN_USER])
+        assert scope.V == frozenset([group.UNKNOWN_USER])
         assert scope.RV == frozenset()
 
     def test_valid_scope_create(self) -> None:
         scope = PermissionScope.create(
-            CR={group.SYSTEM_ADMIN},
-            D={group.PROJECT_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
-            V={group.UNKNOWN_USER},
+            CR=[group.SYSTEM_ADMIN],
+            D=[group.PROJECT_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
+            V=[group.UNKNOWN_USER],
         )
-        assert scope.CR == frozenset({group.SYSTEM_ADMIN})
-        assert scope.D == frozenset({group.PROJECT_ADMIN})
-        assert scope.M == frozenset({group.PROJECT_MEMBER, group.KNOWN_USER})
-        assert scope.V == frozenset({group.UNKNOWN_USER})
+        assert scope.CR == frozenset([group.SYSTEM_ADMIN])
+        assert scope.D == frozenset([group.PROJECT_ADMIN])
+        assert scope.M == frozenset([group.PROJECT_MEMBER, group.KNOWN_USER])
+        assert scope.V == frozenset([group.UNKNOWN_USER])
         assert scope.RV == frozenset()
 
     def test_valid_scope_from_dict(self) -> None:
@@ -60,30 +60,30 @@ class TestScopeCreation:
     def test_same_group_in_multiple_fields(self) -> None:
         with pytest.raises(ValueError, match=re.escape("must not occur in more than one field")):
             PermissionScope.create(
-                CR={group.PROJECT_ADMIN},
-                D={group.PROJECT_ADMIN},
-                V={group.UNKNOWN_USER, group.KNOWN_USER},
+                CR=[group.PROJECT_ADMIN],
+                D=[group.PROJECT_ADMIN],
+                V=[group.UNKNOWN_USER, group.KNOWN_USER],
             )
 
 
 class TestAdd:
     def test_add_to_scope(self) -> None:
         scope = PermissionScope.create(
-            D={group.SYSTEM_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
+            D=[group.SYSTEM_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
         )
         scope = scope.add("CR", group.PROJECT_ADMIN)
         scope_expected = PermissionScope.create(
-            CR={group.PROJECT_ADMIN},
-            D={group.SYSTEM_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
+            CR=[group.PROJECT_ADMIN],
+            D=[group.SYSTEM_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
         )
         assert scope == scope_expected
 
     def test_add_same_group_to_same_permission(self) -> None:
         scope = PermissionScope.create(
-            CR={group.PROJECT_ADMIN},
-            V={group.UNKNOWN_USER, group.KNOWN_USER},
+            CR=[group.PROJECT_ADMIN],
+            V=[group.UNKNOWN_USER, group.KNOWN_USER],
         )
         rgx = "Group 'val='knora-admin:ProjectAdmin'' is already in permission 'CR'"
         with pytest.raises(ValueError, match=re.escape(rgx)):
@@ -91,8 +91,8 @@ class TestAdd:
 
     def test_add_same_group_to_different_permission(self) -> None:
         scope = PermissionScope.create(
-            CR={group.PROJECT_ADMIN},
-            V={group.UNKNOWN_USER, group.KNOWN_USER},
+            CR=[group.PROJECT_ADMIN],
+            V=[group.UNKNOWN_USER, group.KNOWN_USER],
         )
         with pytest.raises(ValueError, match=re.escape("must not occur in more than one field")):
             _ = scope.add("RV", group.PROJECT_ADMIN)
@@ -101,29 +101,29 @@ class TestAdd:
 class TestRemove:
     def test_remove_from_scope(self) -> None:
         scope = PermissionScope.create(
-            CR={group.PROJECT_ADMIN},
-            D={group.SYSTEM_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
+            CR=[group.PROJECT_ADMIN],
+            D=[group.SYSTEM_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
         )
         scope = scope.remove("CR", group.PROJECT_ADMIN)
         scope_expected = PermissionScope.create(
-            D={group.SYSTEM_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
+            D=[group.SYSTEM_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
         )
         assert scope == scope_expected
 
     def test_remove_inexisting_group(self) -> None:
         scope = PermissionScope.create(
-            D={group.SYSTEM_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
+            D=[group.SYSTEM_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
         )
         with pytest.raises(ValueError, match=re.escape("is not in permission 'D'")):
             _ = scope.remove("D", group.UNKNOWN_USER)
 
     def test_remove_from_empty_perm(self) -> None:
         scope = PermissionScope.create(
-            D={group.PROJECT_ADMIN},
-            V={group.PROJECT_MEMBER, group.UNKNOWN_USER},
+            D=[group.PROJECT_ADMIN],
+            V=[group.PROJECT_MEMBER, group.UNKNOWN_USER],
         )
         with pytest.raises(ValueError, match=re.escape("is not in permission 'CR'")):
             _ = scope.remove("CR", group.PROJECT_ADMIN)
@@ -132,23 +132,23 @@ class TestRemove:
 class TestGet:
     def test_get(self) -> None:
         scope = PermissionScope.create(
-            CR={group.PROJECT_ADMIN},
-            D={group.SYSTEM_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
-            V={group.UNKNOWN_USER},
+            CR=[group.PROJECT_ADMIN],
+            D=[group.SYSTEM_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
+            V=[group.UNKNOWN_USER],
         )
-        assert scope.get("CR") == frozenset({group.PROJECT_ADMIN})
-        assert scope.get("D") == frozenset({group.SYSTEM_ADMIN})
-        assert scope.get("M") == frozenset({group.PROJECT_MEMBER, group.KNOWN_USER})
-        assert scope.get("V") == frozenset({group.UNKNOWN_USER})
+        assert scope.get("CR") == frozenset([group.PROJECT_ADMIN])
+        assert scope.get("D") == frozenset([group.SYSTEM_ADMIN])
+        assert scope.get("M") == frozenset([group.PROJECT_MEMBER, group.KNOWN_USER])
+        assert scope.get("V") == frozenset([group.UNKNOWN_USER])
         assert scope.get("RV") == frozenset()
 
     def test_get_inexisting_perm(self) -> None:
         scope = PermissionScope.create(
-            CR={group.PROJECT_ADMIN},
-            D={group.SYSTEM_ADMIN},
-            M={group.PROJECT_MEMBER, group.KNOWN_USER},
-            V={group.UNKNOWN_USER},
+            CR=[group.PROJECT_ADMIN],
+            D=[group.SYSTEM_ADMIN],
+            M=[group.PROJECT_MEMBER, group.KNOWN_USER],
+            V=[group.UNKNOWN_USER],
         )
         with pytest.raises(ValueError, match=re.escape("Permission 'foo' not in")):
             _ = scope.get("foo")

--- a/tests/test_scope_serialization.py
+++ b/tests/test_scope_serialization.py
@@ -53,18 +53,18 @@ class TestScopeSerialization:
             V=[group.Group(val="knora-admin:CustomGroup")],
         ),
         PermissionScope.create(
-            D={group.PROJECT_ADMIN},
-            RV={group.PROJECT_MEMBER},
+            D=[group.PROJECT_ADMIN],
+            RV=[group.PROJECT_MEMBER],
         ),
         PermissionScope.create(
-            M={group.PROJECT_ADMIN},
-            V={group.CREATOR, group.KNOWN_USER},
-            RV={group.UNKNOWN_USER},
+            M=[group.PROJECT_ADMIN],
+            V=[group.CREATOR, group.KNOWN_USER],
+            RV=[group.UNKNOWN_USER],
         ),
         PermissionScope.create(
-            CR={group.SYSTEM_ADMIN, group.PROJECT_ADMIN},
-            D={group.CREATOR},
-            RV={group.UNKNOWN_USER},
+            CR=[group.SYSTEM_ADMIN, group.PROJECT_ADMIN],
+            D=[group.CREATOR],
+            RV=[group.UNKNOWN_USER],
         ),
     )
 


### PR DESCRIPTION
In the database, we'd like that the semantically same things look the same. So the order of the groups matters.
For some reason, this can be achieved by providing the groups as list instead of a set, even though a set is defined as an unordered collection. But as long as it works, I didn't care.