### PR TITLE
test: use patching instead of permanently overwriting names of other modules

### DIFF
--- a/tests/test_ap_set.py
+++ b/tests/test_ap_set.py
@@ -1,12 +1,15 @@
 from typing import Any
 from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
-from dsp_permissions_scripts.ap import ap_set
 from dsp_permissions_scripts.ap.ap_model import ApValue
 from dsp_permissions_scripts.ap.ap_set import create_new_ap_on_server
 from dsp_permissions_scripts.models import group
+
+PROJ_IRI = "http://rdfh.ch/projects/QykAkmHJTPS7ervbGynSHw"
+PROJ_SHORTCODE = "0000"
 
 
 @pytest.fixture
@@ -14,7 +17,7 @@ def create_new_ap_request() -> dict[str, Any]:
     return {
         "forGroup": "http://www.knora.org/ontology/knora-admin#Creator",
         # surprisingly, it also works with "knora-admin:Creator", without context.
-        "forProject": "http://rdfh.ch/projects/QykAkmHJTPS7ervbGynSHw",
+        "forProject": PROJ_IRI,
         "hasPermissions": [
             {"additionalInformation": None, "name": "ProjectResourceCreateAllPermission", "permissionCode": None}
         ],
@@ -26,27 +29,27 @@ def create_new_ap_response() -> dict[str, Any]:
     return {
         "administrative_permission": {
             "iri": "http://rdfh.ch/permissions/4123/8WIp72-IQeKjwL5y7cpNPQ",
-            "forProject": "http://rdfh.ch/projects/QykAkmHJTPS7ervbGynSHw",
+            "forProject": PROJ_IRI,
             "forGroup": "http://www.knora.org/ontology/knora-admin#Creator",
             "hasPermissions": [{"name": "ProjectResourceCreateAllPermission"}],
         }
     }
 
 
-def test_create_new_ap_on_server(create_new_ap_request: dict[str, Any], create_new_ap_response: dict[str, Any]) -> None:
-    ap_set.get_proj_iri_and_onto_iris_by_shortcode = Mock(  # type: ignore[attr-defined]
-        return_value=("http://rdfh.ch/projects/QykAkmHJTPS7ervbGynSHw", None)
-    )
-    ap_set.create_ap_from_admin_route_object = Mock()  # type: ignore[attr-defined]
-    dsp_client = Mock()
-    dsp_client.post = Mock(return_value=create_new_ap_response)
+@patch("dsp_permissions_scripts.ap.ap_set.get_proj_iri_and_onto_iris_by_shortcode", return_value=(PROJ_IRI, None))
+@patch("dsp_permissions_scripts.ap.ap_set.create_ap_from_admin_route_object")
+def test_create_new_ap_on_server(
+    create_ap_from_admin_route_object: Mock,
+    get_proj_iri_and_onto_iris_by_shortcode: Mock,  # noqa: ARG001
+    create_new_ap_request: dict[str, Any],
+    create_new_ap_response: dict[str, Any],
+) -> None:
+    dsp_client = Mock(post=Mock(return_value=create_new_ap_response))
     _ = create_new_ap_on_server(
         forGroup=group.CREATOR,
-        shortcode="0000",
+        shortcode=PROJ_SHORTCODE,
         hasPermissions=[ApValue("ProjectResourceCreateAllPermission")],
         dsp_client=dsp_client,
     )
     dsp_client.post.assert_called_once_with("/admin/permissions/ap", data=create_new_ap_request)
-    ap_set.create_ap_from_admin_route_object.assert_called_once_with(  # type: ignore[attr-defined]
-        create_new_ap_response["administrative_permission"]
-    )
+    create_ap_from_admin_route_object.assert_called_once_with(create_new_ap_response["administrative_permission"])

--- a/tests/test_doap_set.py
+++ b/tests/test_doap_set.py
@@ -1,20 +1,25 @@
 from typing import Any
 from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
-from dsp_permissions_scripts.doap import doap_set
 from dsp_permissions_scripts.doap.doap_model import NewGroupDoapTarget
 from dsp_permissions_scripts.doap.doap_set import create_new_doap_on_server
 from dsp_permissions_scripts.models import group
 from dsp_permissions_scripts.models.scope import PermissionScope
 
+SHORTCODE = "0000"
+ONTO_NAME = "limc"
+MY_RESCLASS_NAME = "MyResclass"
+PROJ_IRI = "http://rdfh.ch/projects/P7Uo3YvDT7Kvv3EvLCl2tw"
+
 
 @pytest.fixture
-def create_new_doap_request() -> dict[str, Any]:
+def request_for_group() -> dict[str, Any]:
     return {
         "forGroup": "http://www.knora.org/ontology/knora-admin#KnownUser",
-        "forProject": "http://rdfh.ch/projects/P7Uo3YvDT7Kvv3EvLCl2tw",
+        "forProject": PROJ_IRI,
         "forProperty": None,
         "forResourceClass": None,
         "hasPermissions": [
@@ -28,11 +33,11 @@ def create_new_doap_request() -> dict[str, Any]:
 
 
 @pytest.fixture
-def create_new_doap_response() -> dict[str, Any]:
+def response_for_group() -> dict[str, Any]:
     return {
         "default_object_access_permission": {
             "iri": "http://rdfh.ch/permissions/4123/grKNPv-tQ7aBYq0mDXyatg",
-            "forProject": "http://rdfh.ch/projects/P7Uo3YvDT7Kvv3EvLCl2tw",
+            "forProject": PROJ_IRI,
             "forGroup": "http://www.knora.org/ontology/knora-admin#KnownUser",
             "hasPermissions": [
                 {
@@ -45,22 +50,22 @@ def create_new_doap_response() -> dict[str, Any]:
     }
 
 
-def test_create_new_doap_on_server(
-    create_new_doap_request: dict[str, Any], create_new_doap_response: dict[str, Any]
+@patch("dsp_permissions_scripts.doap.doap_set.create_doap_from_admin_route_response")
+@patch("dsp_permissions_scripts.doap.doap_set.get_proj_iri_and_onto_iris_by_shortcode", return_value=(PROJ_IRI, None))
+def test_create_doap_for_group(
+    get_project_iri_and_onto_iris_by_shortcode: Mock,  # noqa: ARG001
+    create_doap_from_admin_route_response: Mock,
+    request_for_group: dict[str, Any],
+    response_for_group: dict[str, Any],
 ) -> None:
-    doap_set.get_proj_iri_and_onto_iris_by_shortcode = Mock(  # type: ignore[attr-defined]
-        return_value=("http://rdfh.ch/projects/P7Uo3YvDT7Kvv3EvLCl2tw", None)
-    )
-    doap_set.create_doap_from_admin_route_response = Mock()  # type: ignore[attr-defined]
-    dsp_client = Mock()
-    dsp_client.post = Mock(return_value=create_new_doap_response)
+    dsp_client = Mock(post=Mock(return_value=response_for_group))
     _ = create_new_doap_on_server(
         target=NewGroupDoapTarget(group=group.KNOWN_USER),
-        shortcode="0000",
+        shortcode=SHORTCODE,
         scope=PermissionScope.create(V=[group.UNKNOWN_USER]),
         dsp_client=dsp_client,
     )
-    dsp_client.post.assert_called_once_with("/admin/permissions/doap", data=create_new_doap_request)
-    doap_set.create_doap_from_admin_route_response.assert_called_once_with(  # type: ignore[attr-defined]
-        create_new_doap_response["default_object_access_permission"]
+    dsp_client.post.assert_called_once_with("/admin/permissions/doap", data=request_for_group)
+    create_doap_from_admin_route_response.assert_called_once_with(
+        response_for_group["default_object_access_permission"]
     )

--- a/tests/test_oap_get.py
+++ b/tests/test_oap_get.py
@@ -1,5 +1,6 @@
 from typing import Any
 from unittest.mock import Mock
+from unittest.mock import patch
 from urllib.parse import quote
 
 import pytest
@@ -7,7 +8,6 @@ from pytest_unordered import unordered
 
 from dsp_permissions_scripts.models import group
 from dsp_permissions_scripts.models.scope import PermissionScope
-from dsp_permissions_scripts.oap import oap_get
 from dsp_permissions_scripts.oap.oap_get import KB_RESCLASSES
 from dsp_permissions_scripts.oap.oap_get import _get_oap_of_one_resource
 from dsp_permissions_scripts.oap.oap_get import _get_oaps_of_one_kb_resclass
@@ -18,6 +18,11 @@ from dsp_permissions_scripts.oap.oap_model import OapRetrieveConfig
 from dsp_permissions_scripts.oap.oap_model import ResourceOap
 from dsp_permissions_scripts.oap.oap_model import ValueOap
 from dsp_permissions_scripts.utils.dsp_client import DspClient
+
+# ruff: noqa: PT019
+
+_GET_OAPS_OF_SPECIFIED_KB_RESCLASSES = "dsp_permissions_scripts.oap.oap_get._get_oaps_of_specified_kb_resclasses"
+_ENRICH_WITH_VALUE_OAPS = "dsp_permissions_scripts.oap.oap_get._enrich_with_value_oaps"
 
 
 @pytest.fixture
@@ -373,8 +378,7 @@ def test_get_oap_of_one_resource_some_classes_some_values(resource: dict[str, An
 
 class Test_get_oaps_of_one_kb_resclass:
     def test_get_oaps_of_one_kb_resclass_0_results(self) -> None:
-        dsp_client = Mock(spec=DspClient)
-        dsp_client.get = Mock(side_effect=[{}])
+        dsp_client = Mock(spec=DspClient, get=Mock(side_effect=[{}]))
         res = _get_oaps_of_one_kb_resclass(dsp_client, "proj_iri", "resclass")
         assert res == []
         assert len(dsp_client.get.call_args_list) == 1
@@ -385,8 +389,7 @@ class Test_get_oaps_of_one_kb_resclass:
         assert quote("OFFSET 0", safe="") in called_route
 
     def test_get_oaps_of_one_kb_resclass_1_result(self, gravsearch_1_link_obj: dict[str, Any]) -> None:
-        dsp_client = Mock(spec=DspClient)
-        dsp_client.get = Mock(side_effect=[gravsearch_1_link_obj])
+        dsp_client = Mock(spec=DspClient, get=Mock(side_effect=[gravsearch_1_link_obj]))
         res = _get_oaps_of_one_kb_resclass(dsp_client, "proj_iri", "resclass")
         expected = Oap(
             resource_oap=ResourceOap(
@@ -401,8 +404,7 @@ class Test_get_oaps_of_one_kb_resclass:
         self,
         gravsearch_4_link_objs_on_2_pages: list[dict[str, Any]],
     ) -> None:
-        dsp_client = Mock(spec=DspClient)
-        dsp_client.get = Mock(side_effect=gravsearch_4_link_objs_on_2_pages)
+        dsp_client = Mock(spec=DspClient, get=Mock(side_effect=gravsearch_4_link_objs_on_2_pages))
         res = _get_oaps_of_one_kb_resclass(dsp_client, "proj_iri", "resclass")
         expected_scope = PermissionScope.create(CR=[group.PROJECT_ADMIN], D=[group.PROJECT_MEMBER])
         expected_res_oaps = [
@@ -421,22 +423,24 @@ class Test_get_oaps_of_one_kb_resclass:
         assert quote("OFFSET 1", safe="") in called_route_2
 
 
+@patch(_GET_OAPS_OF_SPECIFIED_KB_RESCLASSES, side_effect=[["res_only_oap_1", "res_only_oap_2"]])
+@patch(_ENRICH_WITH_VALUE_OAPS, side_effect=[["enriched_oap_1", "enriched_oap_2"]])
 class Test_get_oaps_of_kb_resclasses:
-    def test_get_oaps_of_kb_resclasses_all_resclasses_all_values(self) -> None:
-        oap_get._get_oaps_of_specified_kb_resclasses = Mock(side_effect=[["res_only_oap_1", "res_only_oap_2"]])
-        oap_get._enrich_with_value_oaps = Mock(side_effect=[["enriched_oap_1", "enriched_oap_2"]])
+    def test_get_oaps_of_kb_resclasses_all_resclasses_all_values(
+        self, _enrich_with_value_oaps: Mock, _get_oaps_of_specified_kb_resclasses: Mock
+    ) -> None:
         dsp_client = Mock(spec=DspClient)
         oap_config = OapRetrieveConfig(
             retrieve_resources="all",
             retrieve_values="all",
         )
         _ = get_oaps_of_kb_resclasses(dsp_client, "proj_iri", oap_config)
-        oap_get._get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", KB_RESCLASSES)
-        oap_get._enrich_with_value_oaps.assert_called_once_with(dsp_client, ["res_only_oap_1", "res_only_oap_2"])
+        _get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", KB_RESCLASSES)
+        _enrich_with_value_oaps.assert_called_once_with(dsp_client, ["res_only_oap_1", "res_only_oap_2"])
 
-    def test_get_oaps_of_kb_resclasses_all_resclasses_specified_values(self) -> None:
-        oap_get._get_oaps_of_specified_kb_resclasses = Mock(side_effect=[["res_only_oap_1", "res_only_oap_2"]])
-        oap_get._enrich_with_value_oaps = Mock(side_effect=[["enriched_oap_1", "enriched_oap_2"]])
+    def test_get_oaps_of_kb_resclasses_all_resclasses_specified_values(
+        self, _enrich_with_value_oaps: Mock, _get_oaps_of_specified_kb_resclasses: Mock
+    ) -> None:
         dsp_client = Mock(spec=DspClient)
         oap_config = OapRetrieveConfig(
             retrieve_resources="all",
@@ -444,26 +448,26 @@ class Test_get_oaps_of_kb_resclasses:
             specified_props=["onto:prop_1", "onto:prop_2"],
         )
         _ = get_oaps_of_kb_resclasses(dsp_client, "proj_iri", oap_config)
-        oap_get._get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", KB_RESCLASSES)
-        oap_get._enrich_with_value_oaps.assert_called_once_with(
+        _get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", KB_RESCLASSES)
+        _enrich_with_value_oaps.assert_called_once_with(
             dsp_client, ["res_only_oap_1", "res_only_oap_2"], ["onto:prop_1", "onto:prop_2"]
         )
 
-    def test_get_oaps_of_kb_resclasses_all_resclasses_no_values(self) -> None:
-        oap_get._get_oaps_of_specified_kb_resclasses = Mock(side_effect=[["res_only_oap_1", "res_only_oap_2"]])
-        oap_get._enrich_with_value_oaps = Mock(side_effect=[["enriched_oap_1", "enriched_oap_2"]])
+    def test_get_oaps_of_kb_resclasses_all_resclasses_no_values(
+        self, _enrich_with_value_oaps: Mock, _get_oaps_of_specified_kb_resclasses: Mock
+    ) -> None:
         dsp_client = Mock(spec=DspClient)
         oap_config = OapRetrieveConfig(
             retrieve_resources="all",
             retrieve_values="none",
         )
         _ = get_oaps_of_kb_resclasses(dsp_client, "proj_iri", oap_config)
-        oap_get._get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", KB_RESCLASSES)
-        oap_get._enrich_with_value_oaps.assert_not_called()
+        _get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", KB_RESCLASSES)
+        _enrich_with_value_oaps.assert_not_called()
 
-    def test_get_oaps_of_kb_resclasses_some_resclasses_all_values(self) -> None:
-        oap_get._get_oaps_of_specified_kb_resclasses = Mock(side_effect=[["res_only_oap_1", "res_only_oap_2"]])
-        oap_get._enrich_with_value_oaps = Mock(side_effect=[["enriched_oap_1", "enriched_oap_2"]])
+    def test_get_oaps_of_kb_resclasses_some_resclasses_all_values(
+        self, _enrich_with_value_oaps: Mock, _get_oaps_of_specified_kb_resclasses: Mock
+    ) -> None:
         dsp_client = Mock(spec=DspClient)
         oap_config = OapRetrieveConfig(
             retrieve_resources="specified_res_classes",
@@ -471,14 +475,12 @@ class Test_get_oaps_of_kb_resclasses:
             retrieve_values="all",
         )
         _ = get_oaps_of_kb_resclasses(dsp_client, "proj_iri", oap_config)
-        oap_get._get_oaps_of_specified_kb_resclasses.assert_called_once_with(
-            dsp_client, "proj_iri", ["knora-api:Region"]
-        )
-        oap_get._enrich_with_value_oaps.assert_called_once_with(dsp_client, ["res_only_oap_1", "res_only_oap_2"])
+        _get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", ["knora-api:Region"])
+        _enrich_with_value_oaps.assert_called_once_with(dsp_client, ["res_only_oap_1", "res_only_oap_2"])
 
-    def test_get_oaps_of_kb_resclasses_some_resclasses_some_values(self) -> None:
-        oap_get._get_oaps_of_specified_kb_resclasses = Mock(side_effect=[["res_only_oap_1", "res_only_oap_2"]])
-        oap_get._enrich_with_value_oaps = Mock(side_effect=[["enriched_oap_1", "enriched_oap_2"]])
+    def test_get_oaps_of_kb_resclasses_some_resclasses_some_values(
+        self, _enrich_with_value_oaps: Mock, _get_oaps_of_specified_kb_resclasses: Mock
+    ) -> None:
         dsp_client = Mock(spec=DspClient)
         oap_config = OapRetrieveConfig(
             retrieve_resources="specified_res_classes",
@@ -487,16 +489,14 @@ class Test_get_oaps_of_kb_resclasses:
             specified_props=["onto:prop_1", "onto:prop_2"],
         )
         _ = get_oaps_of_kb_resclasses(dsp_client, "proj_iri", oap_config)
-        oap_get._get_oaps_of_specified_kb_resclasses.assert_called_once_with(
-            dsp_client, "proj_iri", ["knora-api:Region"]
-        )
-        oap_get._enrich_with_value_oaps.assert_called_once_with(
+        _get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", ["knora-api:Region"])
+        _enrich_with_value_oaps.assert_called_once_with(
             dsp_client, ["res_only_oap_1", "res_only_oap_2"], ["onto:prop_1", "onto:prop_2"]
         )
 
-    def test_get_oaps_of_kb_resclasses_some_resclasses_no_values(self) -> None:
-        oap_get._get_oaps_of_specified_kb_resclasses = Mock(side_effect=[["res_only_oap_1", "res_only_oap_2"]])
-        oap_get._enrich_with_value_oaps = Mock(side_effect=[["enriched_oap_1", "enriched_oap_2"]])
+    def test_get_oaps_of_kb_resclasses_some_resclasses_no_values(
+        self, _enrich_with_value_oaps: Mock, _get_oaps_of_specified_kb_resclasses: Mock
+    ) -> None:
         dsp_client = Mock(spec=DspClient)
         oap_config = OapRetrieveConfig(
             retrieve_resources="specified_res_classes",
@@ -504,7 +504,5 @@ class Test_get_oaps_of_kb_resclasses:
             retrieve_values="none",
         )
         _ = get_oaps_of_kb_resclasses(dsp_client, "proj_iri", oap_config)
-        oap_get._get_oaps_of_specified_kb_resclasses.assert_called_once_with(
-            dsp_client, "proj_iri", ["knora-api:Region"]
-        )
-        oap_get._enrich_with_value_oaps.assert_not_called()
+        _get_oaps_of_specified_kb_resclasses.assert_called_once_with(dsp_client, "proj_iri", ["knora-api:Region"])
+        _enrich_with_value_oaps.assert_not_called()


### PR DESCRIPTION
The currently used construct is problematic: `doap_set.create_doap_from_admin_route_response = Mock()` permanently overwrites that name in the other module. This can cause subsequent tests to fail unexpectedly, which is difficult to debug.
Instead, https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch should be used to patch names of other modules temporarily.